### PR TITLE
Added options for publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@senseering/worker",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@senseering/worker",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@senseering/worker",
-    "version": "1.6.0",
+    "version": "1.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@senseering/worker",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Client library to connect to the [manager](https://github.com/Senseering/manager).",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@senseering/worker",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "description": "Client library to connect to the [manager](https://github.com/Senseering/manager).",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@senseering/worker",
-    "version": "1.6.0",
+    "version": "1.5.1",
     "description": "Client library to connect to the [manager](https://github.com/Senseering/manager).",
     "main": "index.js",
     "scripts": {

--- a/src/worker.js
+++ b/src/worker.js
@@ -92,11 +92,13 @@ Worker.prototype.publish = async function (data, options) {
     let result
     let meta = {
         worker_id: (await config.get('credentials')).split(":")[0],
-        created_at: Date.now(),
         price: options.price === undefined ? 0 : options.price,
-        location: (await config.get('profile')).location,
         custom: await config.get('meta')
     }
+    // Set timestamp and location to parameters given by options or to parameters defined in config if they are not defined by options
+    meta.created_at = options.created_at !== undefined ? options.created_at : Date.now()
+    meta.location = options.location !== undefined ? options.location : (await config.get('profile')).location
+
     //append basedOn property just in case of service
     if (Object.keys((await config.get('schema')).input).length) {
         meta.basedOn = {


### PR DESCRIPTION
## Proposed changes
Option to define created_at and location via options parameter in publish method
### Short description
It is now possible to define the timestamp and location parameter of the metadata by defining them in the options parameter of the publish method. If they are not defined within they are taken from the config.
### Issues

closes #the-issue-number
### Update size
patch